### PR TITLE
fix(op_stack): use adm to fetch data in F4 et 62 opcodes

### DIFF
--- a/cpu/op_stack.go
+++ b/cpu/op_stack.go
@@ -5,8 +5,8 @@ import (
 )
 
 //opF4 pushes the next 16bit value into the stack
-func (cpu *CPU) opF4(data uint16) {
-	dataHi, dataLo := utils.SplitUint16(data)
+func (cpu *CPU) opF4() {
+	dataHi, dataLo := cpu.admImmediate16()
 	cpu.pushStack(dataHi)
 	cpu.pushStack(dataLo)
 	cpu.cycles += 5
@@ -21,8 +21,8 @@ func (cpu *CPU) opD4() {
 }
 
 //op62 pushes 16bit data into the stack, called thanks to the next 8bit value
-func (cpu *CPU) op62(data uint16) {
-	dataHi, dataLo := utils.SplitUint16(data)
+func (cpu *CPU) op62() {
+	dataHi, dataLo := cpu.admImmediate16()
 	cpu.pushStack(dataHi)
 	cpu.pushStack(dataLo)
 	cpu.cycles += 6


### PR DESCRIPTION
Opcodes shouldn't have arguments, they should get their data using the correct addressing mode method