### PR TITLE
X y registers fix

### DIFF
--- a/cpu/op_decinc_test.go
+++ b/cpu/op_decinc_test.go
@@ -1,0 +1,28 @@
+package cpu
+
+import "testing"
+
+func TestInx(t *testing.T) {
+
+	testCases := []struct {
+		value          *CPU
+		expected       CPU
+		dataHi, dataLo uint8
+		operator       func(uint8, uint8)
+	}{
+		{
+			value:    &CPU{X: 0x7FFF},
+			expected: CPU{X: 0x8000, nFlag: true},
+		},
+	}
+
+	for i, tc := range testCases {
+		tc.value.opE8()
+
+		err := tc.value.compare(tc.expected)
+
+		if err != nil {
+			t.Errorf("Test %v failed: \n%v", i, err)
+		}
+	}
+}

--- a/cpu/op_flags.go
+++ b/cpu/op_flags.go
@@ -51,7 +51,7 @@ func (cpu *CPU) opC2() {
 	if cpu.eFlag {
 		cpu.bFlag = cpu.bFlag && dataLo&0x10 == 0
 	} else {
-		cpu.xFlag = cpu.xFlag && dataLo&0x10 == 0
+		cpu.setXFlag(cpu.xFlag && dataLo&0x10 == 0)
 	}
 	cpu.mFlag = cpu.mFlag && dataLo&0x20 == 0
 	cpu.vFlag = cpu.vFlag && dataLo&0x40 == 0
@@ -70,7 +70,7 @@ func (cpu *CPU) opE2() {
 	if cpu.eFlag {
 		cpu.bFlag = cpu.bFlag || dataLo&0x10 != 0
 	} else {
-		cpu.xFlag = cpu.xFlag || dataLo&0x10 != 0
+		cpu.setXFlag(cpu.xFlag || dataLo&0x10 != 0)
 	}
 	cpu.mFlag = cpu.mFlag || dataLo&0x20 != 0
 	cpu.vFlag = cpu.vFlag || dataLo&0x40 != 0

--- a/cpu/op_stack.go
+++ b/cpu/op_stack.go
@@ -213,10 +213,10 @@ func (cpu *CPU) plp() {
 	cpu.nFlag = P&0x80 != 0
 	if cpu.eFlag {
 		cpu.bFlag = P&0x10 != 0
-		cpu.xFlag = true
+		cpu.setXFlag(true)
 		cpu.mFlag = true
 	} else {
-		cpu.xFlag = P&0x10 != 0
+		cpu.setXFlag(P&0x10 != 0)
 	}
 }
 

--- a/cpu/register.go
+++ b/cpu/register.go
@@ -179,3 +179,10 @@ func (cpu CPU) getYHRegister() uint8 {
 func (cpu *CPU) setYHRegister(y uint8) {
 	cpu.Y = (cpu.Y & 0x00ff) | uint16(y)
 }
+
+// setXFlag sets the x flag and take care of the reset of X and Y higher bits
+func (cpu *CPU) setXFlag(x bool) {
+	cpu.xFlag = x
+	cpu.setXHRegister(0x00)
+	cpu.setYHRegister(0x00)
+}

--- a/cpu/register.go
+++ b/cpu/register.go
@@ -137,7 +137,7 @@ func (cpu CPU) getXLRegister() uint8 {
 
 // setXLRegister sets the lower 8 bits of the X register
 func (cpu *CPU) setXLRegister(x uint8) {
-	cpu.X = (cpu.X & 0xff00) | uint16(x)
+	cpu.X = uint16(x)
 }
 
 // getXHRegister returns the upper 8 bits of the X index register
@@ -147,7 +147,7 @@ func (cpu CPU) getXHRegister() uint8 {
 
 // setXHRegister sets the upper 8 bits of the X register
 func (cpu *CPU) setXHRegister(x uint8) {
-	cpu.X = (cpu.X & 0x00ff) | uint16(x)
+	cpu.X = uint16(x)
 }
 
 // getYRegister returns the Y index register


### PR DESCRIPTION
Fix the way we set X and y registers,
according to the documentation: 
Furthermore, although "X register" and "Y register" refer to the 16-bit registers, when the x flag is 1, they are equivalent to the XL and YL registers, since the XH and YH register are forced to $00 when the x flag is 1. (See below.) In effect, "X register" means the 16-bit register when the x flag is 0, and the 8-bit register (i.e. the XL register) when the x flag is 1. Likewise for "Y register"