### PR TITLE
Cleanup of xce instruction

### DIFF
--- a/cpu/op_exchange.go
+++ b/cpu/op_exchange.go
@@ -11,9 +11,7 @@ func (cpu *CPU) opEB() {
 }
 
 func (cpu *CPU) opFB() {
-	temp := cpu.eFlag
-	cpu.eFlag = cpu.cFlag
-	cpu.cFlag = temp
+	cpu.eFlag, cpu.cFlag = cpu.cFlag, cpu.eFlag
 	cpu.cycles += 2
 	cpu.PC++
 }


### PR DESCRIPTION
don't use temporary variable since we can use transparent swapping