### PR TITLE
Render backgrounds

### DIFF
--- a/core/objects.go
+++ b/core/objects.go
@@ -4,10 +4,13 @@ import "fmt"
 
 // tile defines how a tile is handled by the super-nes
 type tile struct {
-	number       uint16 // tile number (used to find it in the vram)
-	palette      uint8  // index of the color palette to use (the number of entries in the palette depends on the mode and the background)
-	priority     bool   // Tile priority, for tiles this is only encoded in 1 bit (whereas for sprites it's encoded into 2 bits)
-	hFlip, vFlip bool   // horizontal and vertical flips
+	number        uint16 // tile number (used to find it in the vram)
+	palette       uint8  // index of the color palette to use (the number of entries in the palette depends on the mode and the background)
+	priority      bool   // Tile priority, for tiles this is only encoded in 1 bit (whereas for sprites it's encoded into 2 bits)
+	hFlip, vFlip  bool   // horizontal and vertical flips
+	firstTileAddr uint32 // address of the first 8x8 tile composing the complete background tile
+	colorDepth    uint8  // number of bits used to addres the colors
+	hSize, vSize  uint16 // horizontal and vertical size
 }
 
 // sprite defines how a sprite is handled by the super-nes

--- a/core/ppu_bg.go
+++ b/core/ppu_bg.go
@@ -104,7 +104,7 @@ func (ppu *PPU) bgnhofs(bg uint8, data uint8) {
 }
 
 func (ppu *PPU) bgnvofs(bg uint8, data uint8) {
-	ppu.backgroundData.bg[0].verticalScroll = uint16(data&3)<<8 | uint16(ppu.backgroundData.PPU1ScrollLatch)
+	ppu.backgroundData.bg[bg].verticalScroll = uint16(data&3)<<8 | uint16(ppu.backgroundData.PPU1ScrollLatch)
 	ppu.backgroundData.PPU1ScrollLatch = data
 }
 

--- a/core/ppu_bg.go
+++ b/core/ppu_bg.go
@@ -219,6 +219,17 @@ func (bg *bg) tileSize() (uint16, uint16) {
 	return hSize, vSize
 }
 
+// 			1   2   3   4
+// ======---=---=---=---=
+// 0        4   4   4   4
+// 1       16  16   4   -
+// 2       16  16   -   -
+// 3      256  16   -   -
+// 4      256   4   -   -
+// 5       16   4   -   -
+// 6       16   -   -   -
+// 7      256   -   -   -
+// 7EXTBG 256 128   -   -
 // colorDepth returns the number of bits used for the colors in the background
 func (ppu *PPU) colorDepth(background uint8) uint8 {
 	switch ppu.backgroundData.screenMode {

--- a/core/ppu_bg.go
+++ b/core/ppu_bg.go
@@ -193,14 +193,16 @@ func (ppu *PPU) tileFromBackground(background uint8, x uint16, y uint16) bgTile 
 	tileNumber := raw & 0x3FF
 
 	return bgTile{
-		vFlip:         raw&0x8000 != 0,
-		hFlip:         raw&0x4000 != 0,
-		priority:      raw&0x2000 != 0,
-		palette:       uint8((raw >> 10) & 0x7),
-		firstTileAddr: uint16(bg.tileSetBaseAddr)<<13 + uint16(tileNumber)*baseTileSize(colorDepth),
-		colorDepth:    ppu.colorDepth(background),
-		hSize:         hSize,
-		vSize:         vSize,
+		baseTile: baseTile{
+			palette:    uint8((raw >> 10) & 0x7),
+			addr:       uint16(bg.tileSetBaseAddr)<<13 + uint16(tileNumber)*baseTileSize(colorDepth),
+			colorDepth: ppu.colorDepth(background),
+		},
+		vFlip:    raw&0x8000 != 0,
+		hFlip:    raw&0x4000 != 0,
+		priority: raw&0x2000 != 0,
+		hSize:    hSize,
+		vSize:    vSize,
 	}
 }
 

--- a/core/ppu_bg.go
+++ b/core/ppu_bg.go
@@ -6,6 +6,9 @@ import (
 	"github.com/snes-emu/gose/bit"
 )
 
+//used in ppu.colorDepth
+const panicString = "in mode %d, only background 1,2,3 are valid, attempted to use background %d"
+
 type backgroundData struct {
 	bg              [4]*bg // BG array containing the 4 backgrounds
 	PPU1ScrollLatch uint8  // latch for background offset in PPU1
@@ -218,7 +221,6 @@ func (bg *bg) tileSize() (uint16, uint16) {
 
 // colorDepth returns the number of bits used for the colors in the background
 func (ppu *PPU) colorDepth(background uint8) uint8 {
-	panicString := "in mode %d, only background 1,2,3 are valid, attempted to use background %d"
 	switch ppu.backgroundData.screenMode {
 	case 0:
 		return 2
@@ -268,12 +270,9 @@ func (ppu *PPU) colorDepth(background uint8) uint8 {
 		case 0:
 			return 8
 		}
-	default:
-		panic(fmt.Sprintf("invalid mode requested: %d", ppu.backgroundData.screenMode))
 	}
 
-	//should never happen
-	return 0
+	panic(fmt.Sprintf("invalid mode requested: %d", ppu.backgroundData.screenMode))
 }
 
 //validBackgrounds are the backgrounds that can be used for the current screen mode

--- a/core/ppu_bg.go
+++ b/core/ppu_bg.go
@@ -98,59 +98,59 @@ func (ppu *PPU) bg34nba(data uint8) {
 
 // 210Dh - 2114h horizontal and vertical background offset: https://forums.nesdev.com/viewtopic.php?t=15228 for the formula
 func (ppu *PPU) bgnhofs(bg uint8, data uint8) {
-	ppu.backgroundData.bg[bg].horizontalScroll = uint16(data&3)<<8 | uint16((ppu.backgroundData.PPU1ScrollLatch &^ 7)) | uint16(ppu.backgroundData.PPU2ScrollLatch&7)
+	ppu.backgroundData.bg[bg-1].horizontalScroll = uint16(data&3)<<8 | uint16((ppu.backgroundData.PPU1ScrollLatch &^ 7)) | uint16(ppu.backgroundData.PPU2ScrollLatch&7)
 	ppu.backgroundData.PPU1ScrollLatch = data
 	ppu.backgroundData.PPU2ScrollLatch = data
 }
 
 func (ppu *PPU) bgnvofs(bg uint8, data uint8) {
-	ppu.backgroundData.bg[bg].verticalScroll = uint16(data&3)<<8 | uint16(ppu.backgroundData.PPU1ScrollLatch)
+	ppu.backgroundData.bg[bg-1].verticalScroll = uint16(data&3)<<8 | uint16(ppu.backgroundData.PPU1ScrollLatch)
 	ppu.backgroundData.PPU1ScrollLatch = data
 }
 
 // 210Dh - BG1HOFS - BG1 Horizontal Scroll (X) (W)
 func (ppu *PPU) bg1hofs(data uint8) {
-	ppu.bgnhofs(0, data)
+	ppu.bgnhofs(1, data)
 	ppu.m7hofs(data)
 }
 
 // 210Eh - BG1VOFS - BG1 Vertical Scroll (Y) (W)
 func (ppu *PPU) bg1vofs(data uint8) {
-	ppu.bgnvofs(0, data)
+	ppu.bgnvofs(1, data)
 	ppu.m7vofs(data)
 }
 
 // 210Fh - BG2HOFS - BG2 Horizontal Scroll (X) (W)
 func (ppu *PPU) bg2hofs(data uint8) {
-	ppu.bgnhofs(1, data)
+	ppu.bgnhofs(2, data)
 
 }
 
 // 2110h - BG2VOFS - BG2 Vertical Scroll (Y) (W)
 func (ppu *PPU) bg2vofs(data uint8) {
-	ppu.bgnvofs(1, data)
+	ppu.bgnvofs(2, data)
 }
 
 // 2111h - BG3HOFS - BG3 Horizontal Scroll (X) (W)
 func (ppu *PPU) bg3hofs(data uint8) {
-	ppu.bgnhofs(2, data)
+	ppu.bgnhofs(3, data)
 
 }
 
 // 2112h - BG3VOFS - BG3 Vertical Scroll (Y) (W)
 func (ppu *PPU) bg3vofs(data uint8) {
-	ppu.bgnvofs(2, data)
+	ppu.bgnvofs(3, data)
 }
 
 // 2113h - BG4HOFS - BG4 Horizontal Scroll (X) (W)
 func (ppu *PPU) bg4hofs(data uint8) {
-	ppu.bgnhofs(3, data)
+	ppu.bgnhofs(4, data)
 
 }
 
 // 2114h - BG4VOFS - BG4 Vertical Scroll (Y) (W)
 func (ppu *PPU) bg4vofs(data uint8) {
-	ppu.bgnvofs(3, data)
+	ppu.bgnvofs(4, data)
 }
 
 // tileMapAddress returns the byte address in the VRAM of the tile we are looking for in the tilemap

--- a/core/ppu_cgram.go
+++ b/core/ppu_cgram.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"image/color"
+
 	"github.com/snes-emu/gose/bit"
 	"github.com/snes-emu/gose/render"
-	"image/color"
 )
 
 const cgramSize = 0x200
@@ -128,14 +129,35 @@ func (ppu *PPU) tileSpriteRowColor(tileAddress, y uint16, palette uint8) [TILE_S
 	return colors
 }
 
-// tileSpriteColor returns the color to use for a given tile's pixel in the given sprite
+// tileRowColors returns the colors to use for a given tile's row
 // tileAddress is the tile address in the vram
+// hSize is the horizontal size of the tile: either 8 or 16
+// y is the row number inside the tile (from 0 to 7 included)
+// palette is the palette we should use
+func (ppu *PPU) tileRowColor(tileAddress, colorDepth, hSize, y uint16, palette uint8) []render.BGR555 {
+	colors := make([]render.BGR555, hSize)
+
+	for x := uint16(0); x < hSize; x++ {
+		colors[x] = ppu.tileColor(tileAddress, colorDepth, x, y, palette)
+	}
+
+	return colors
+}
+
+// tileSpriteColor is like tileColor but for sprites
+func (ppu *PPU) tileSpriteColor(tileAddress, x, y uint16, palette uint8) render.BGR555 {
+	// For sprites the color depth is always 4
+	return ppu.tileColor(tileAddress, 4, x, y, palette)
+}
+
+// tileColor returns the color to use for a given tile's pixel in the given sprite
+// tileAddress is the tile address in the vram
+// colorDepth is the number of bits used per color
 // x is the x position of the pixel inside the tile (from 0 to 7 included)
 // y is the y position of the pixel inside the tile (from 0 to 7 included)
 // palette is the palette we should use
-func (ppu *PPU) tileSpriteColor(tileAddress, x, y uint16, palette uint8) render.BGR555 {
-	// For sprites the color depth is always 4
-	idx := ppu.colorIndex(tileAddress, 4, x, y)
+func (ppu *PPU) tileColor(tileAddress, colorDepth, x, y uint16, palette uint8) render.BGR555 {
+	idx := ppu.colorIndex(tileAddress, colorDepth, x, y)
 
 	if idx == 0 {
 		return render.BGR555{Transparent: true}

--- a/core/ppu_cgram.go
+++ b/core/ppu_cgram.go
@@ -169,3 +169,12 @@ func (ppu *PPU) tileColor(tileAddress, colorDepth, x, y uint16, palette uint8) r
 		Color: bit.JoinUint16(ppu.cgram.bytes[colorWordAddr], ppu.cgram.bytes[colorWordAddr+1]),
 	}.ApplyBrightness(ppu.display.brightness)
 }
+
+func (ppu *PPU) backdropPixel() render.Pixel {
+	return render.Pixel{
+		Visible: true,
+		Color: render.BGR555{
+			Color: bit.JoinUint16(ppu.cgram.bytes[0], ppu.cgram.bytes[1]),
+		},
+	}
+}

--- a/core/ppu_oam.go
+++ b/core/ppu_oam.go
@@ -149,6 +149,9 @@ func (o *oam) sprite(idx uint16) sprite {
 
 	sprite := sprite{}
 
+	// sprites always use 16 colors
+	sprite.colorDepth = 4
+
 	// Read x, y, and firstTileAddress low word
 	sprite.x = uint16(raw1[0])
 	sprite.y = uint16(raw1[1])
@@ -180,9 +183,9 @@ func (o *oam) sprite(idx uint16) sprite {
 	// See: https://wiki.superfamicom.org/sprites
 	// The formula in wiki.superfamicom.com is given as word address (hence 2 bytes)
 	// that's why they limit the result to 32KB
-	sprite.firstTileAddr = (o.baseAddr << 14) + (tileIdx << 5)
+	sprite.addr = (o.baseAddr << 14) + (tileIdx << 5)
 	if attrs&0x1 != 0 {
-		sprite.firstTileAddr += (1 + o.nameSelect) << 13
+		sprite.addr += (1 + o.nameSelect) << 13
 	}
 
 	return sprite

--- a/core/ppu_render.go
+++ b/core/ppu_render.go
@@ -211,7 +211,11 @@ func (ppu *PPU) bgToImage(bgIndex uint8) image.Image {
 					for y := uint16(0); y < bgTile.vSize; y++ {
 						for x, color := range ppu.tileRowColor(tile, y) {
 							if !color.Transparent {
-								img.Set(int(xBgTile*bgTile.hSize+xTile*TILE_SIZE+uint16(x)), int(yBgTile*bgTile.vSize+yTile*TILE_SIZE+uint16(y)), color)
+								img.Set(
+									int(xBgTile*bgTile.hSize+xTile*TILE_SIZE+uint16(x)),
+									int(yBgTile*bgTile.vSize+yTile*TILE_SIZE+uint16(y)),
+									color,
+								)
 							}
 						}
 					}

--- a/core/ppu_render.go
+++ b/core/ppu_render.go
@@ -23,6 +23,7 @@ func (ppu *PPU) renderLine() {
 	ppu.vCounter = (ppu.vCounter + 1) % ppu.VDisplayEnd()
 
 	if ppu.vCounter < ppu.screen.Height {
+		ppu.screen.SetPixelLine(ppu.vCounter, ppu.backdropPixelLine())
 		ppu.screen.SetPixelLine(ppu.vCounter, ppu.spritesToPixelLine(ppu.oam.intersectingSprites(ppu.vCounter)))
 	}
 
@@ -86,6 +87,16 @@ func (ppu *PPU) spritesToPixelLine(sprites []sprite) []render.Pixel {
 				}
 			}
 		}
+	}
+
+	return pixels
+}
+
+func (ppu *PPU) backdropPixelLine() []render.Pixel {
+	pixels := make([]render.Pixel, WIDTH)
+	backdropPixel := ppu.backdropPixel()
+	for i := range pixels {
+		pixels[i] = backdropPixel
 	}
 
 	return pixels

--- a/core/ppu_render.go
+++ b/core/ppu_render.go
@@ -1,9 +1,13 @@
 package core
 
 import (
+	"fmt"
+	"image"
+	"image/png"
+	"os"
+
 	"github.com/snes-emu/gose/log"
 	"github.com/snes-emu/gose/render"
-	"image"
 )
 
 const WIDTH = 250
@@ -26,6 +30,17 @@ func (ppu *PPU) renderLine() {
 		ppu.renderer.Render(ppu.screen)
 		log.Debug("VBlank")
 		ppu.cpu.enterVblank()
+
+		for i, img := range ppu.Backgrounds() {
+			f, err := os.Create(fmt.Sprintf("/tmp/bg%d.png", i))
+			if err != nil {
+				panic(err)
+			}
+			err = png.Encode(f, img)
+			if err != nil {
+				panic(err)
+			}
+		}
 	}
 
 	if ppu.vCounter == 0 {
@@ -110,5 +125,42 @@ func (ppu *PPU) Sprites() []image.Image {
 	for i, sprite := range sprites {
 		images[i] = ppu.spriteToImage(sprite)
 	}
+	return images
+}
+
+func (ppu *PPU) bgToImage(bgIndex uint8) image.Image {
+	bg := ppu.backgroundData.bg[bgIndex]
+	sizeInTile := uint16(64)
+	hTileSize, vTileSize := bg.tileSize()
+
+	hSize := sizeInTile * hTileSize
+	vSize := sizeInTile * vTileSize
+	img := image.NewRGBA(image.Rectangle{
+		Min: image.Point{},
+		Max: image.Point{X: int(hSize), Y: int(vSize)},
+	})
+	for yTile := uint16(0); yTile < uint16(sizeInTile); yTile++ {
+		for xTile := uint16(0); xTile < uint16(sizeInTile); xTile++ {
+			tile := ppu.tileFromBackground(bgIndex, xTile, yTile)
+			for y := uint16(0); y < tile.vSize; y++ {
+				for x, color := range ppu.tileRowColor(uint16(tile.firstTileAddr), uint16(tile.colorDepth), hTileSize, y, tile.palette) {
+					if !color.Transparent {
+						img.Set(int(xTile*hTileSize+uint16(x)), int(yTile*vTileSize+uint16(y)), color)
+					}
+				}
+			}
+
+		}
+	}
+
+	return img
+}
+
+func (ppu *PPU) Backgrounds() []image.Image {
+	images := make([]image.Image, 0, 4)
+	for _, bg := range ppu.validBackgrounds() {
+		images = append(images, ppu.bgToImage(bg))
+	}
+
 	return images
 }

--- a/debugger/static/index.js
+++ b/debugger/static/index.js
@@ -64,8 +64,8 @@ registerBreakpointButton.onclick = function() {
     const register = document.getElementById("register_breakpoint");
     fetch('/breakpoint?registers='+register.value);
 }
-const clearRegisterBreakpointButton = document.getElementById("register_breakpoint_button");
-ClearRegisterBreakpointButton.onclick = function() {
+const clearRegisterBreakpointButton = document.getElementById("clear_register_breakpoint_button");
+clearRegisterBreakpointButton.onclick = function() {
     const register = document.getElementById("register_breakpoint");
     register.value = ""
     fetch('/breakpoint?clear=registers');

--- a/render/screen.go
+++ b/render/screen.go
@@ -26,7 +26,9 @@ func (s *Screen) SetPixelLine(line uint16, pixels []Pixel) {
 	if line < s.Height {
 		start := int(line * s.Width)
 		for i, pix := range pixels[:s.Width] {
-			s.Pixels[start+i] = pix
+			if pix.Visible {
+				s.Pixels[start+i] = pix
+			}
 		}
 	} else {
 		panic(fmt.Sprintf("Screen not big enough ! can't set pixels at line %d in screen having only %d lines", line, s.Height))


### PR DESCRIPTION
- Display BG1 on top of the sprites
- Add a function to dump the rendered backgrounds

add something like this during vBlank
```
		for i, img := range ppu.Backgrounds() {
			f, err := os.Create(fmt.Sprintf("/tmp/bg%d.png", i))
			if err != nil {
				panic(err)
			}
			err = png.Encode(f, img)
			if err != nil {
				panic(err)
			}
		}
```

Next we need to handle priorities of the different layers and render the backgrounds according the mode (0-7)