### PR TITLE
Small (but important!) fixes to the cpu

### DIFF
--- a/core/addressing_modes.go
+++ b/core/addressing_modes.go
@@ -76,7 +76,7 @@ func (cpu *CPU) admPAbsoluteXJ() uint16 {
 	LL := cpu.memory.GetByteBank(cpu.getKRegister(), cpu.getPCRegister()+1)
 	HH := cpu.memory.GetByteBank(cpu.getKRegister(), cpu.getPCRegister()+2)
 	address := bit.JoinUint16(LL, HH) + cpu.getXRegister()
-	return bit.JoinUint16(cpu.memory.GetByteBank(0x00, address), cpu.memory.GetByteBank(0x00, address+1))
+	return bit.JoinUint16(cpu.memory.GetByteBank(cpu.getKRegister(), address), cpu.memory.GetByteBank(cpu.getKRegister(), address+1))
 }
 
 // ACCUMULATOR addressing mode

--- a/core/opcodes.go
+++ b/core/opcodes.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"github.com/snes-emu/gose/log"
 	"os"
+
+	"github.com/snes-emu/gose/log"
 
 	"github.com/snes-emu/gose/bit"
 )
@@ -1143,7 +1144,7 @@ func (cpu *CPU) opE8() {
 func (cpu *CPU) opC8() {
 	if cpu.xFlag {
 		result := cpu.getYLRegister() + 1
-		cpu.setXLRegister(result)
+		cpu.setYLRegister(result)
 		// Last bit value
 		cpu.nFlag = result&0x80 != 0
 		// Zero result flag


### PR DESCRIPTION
- INY should increment the Y register
- (Absolute,X) addressing mode fetches the addressing from the current bank (K)