### PR TITLE
Subscreen compositing used for transparency effect

### DIFF
--- a/core/opcodes.go
+++ b/core/opcodes.go
@@ -3472,7 +3472,7 @@ func (cpu *CPU) op9A() {
 }
 
 func (cpu *CPU) txy() {
-	if cpu.eFlag {
+	if cpu.xFlag {
 		result := cpu.getXLRegister()
 		cpu.setYLRegister(result)
 		cpu.nFlag = result&0x80 != 0
@@ -3491,7 +3491,7 @@ func (cpu *CPU) op9B() {
 }
 
 func (cpu *CPU) tya() {
-	if cpu.eFlag {
+	if cpu.mFlag {
 		result := cpu.getYLRegister()
 		cpu.setARegister(result)
 		cpu.nFlag = result&0x80 != 0
@@ -3510,7 +3510,7 @@ func (cpu *CPU) op98() {
 }
 
 func (cpu *CPU) tyx() {
-	if cpu.eFlag {
+	if cpu.xFlag {
 		result := cpu.getYLRegister()
 		cpu.setXLRegister(result)
 		cpu.nFlag = result&0x80 != 0

--- a/core/opcodes.go
+++ b/core/opcodes.go
@@ -1897,7 +1897,7 @@ func (cpu *CPU) stz8(addr uint32) {
 
 // stz stores 0 in the memory taking care of the 16bit/8bit cases
 func (cpu *CPU) stz(laddr, haddr uint32) {
-	if cpu.xFlag {
+	if cpu.mFlag {
 		cpu.stz8(laddr)
 	} else {
 		cpu.stz16(laddr, haddr)

--- a/core/ppu.go
+++ b/core/ppu.go
@@ -36,6 +36,8 @@ type PPU struct {
 
 	cpu         *CPU
 	renderer    render.Renderer
+	mainScreen  []render.Pixel
+	subScreen   []render.Pixel
 	screen      *render.Screen
 	blackScreen *render.Screen
 }
@@ -45,6 +47,8 @@ func newPPU(renderer render.Renderer, rf *io.RegisterFactory) *PPU {
 	ppu := &PPU{}
 	ppu.renderer = renderer
 	// TODO: fix dimensions
+	ppu.mainScreen = make([]render.Pixel, WIDTH)
+	ppu.subScreen = make([]render.Pixel, WIDTH)
 	ppu.screen = render.NewScreen(WIDTH, HEIGHT)
 	ppu.blackScreen = render.NewScreen(WIDTH, HEIGHT)
 	ppu.vram = &vram{}

--- a/core/ppu_colormath.go
+++ b/core/ppu_colormath.go
@@ -1,5 +1,7 @@
 package core
 
+import "github.com/snes-emu/gose/render"
+
 type colorMath struct {
 	mainScreenBlack uint8 // Force main screen black (possible values: (3=Always, 2=MathWindow, 1=NotMathWin, 0=Never))
 	enable          uint8 // Global color math enable (possible values: (0=Always, 1=MathWindow, 2=NotMathWin, 3=Never))
@@ -56,5 +58,18 @@ func (ppu *PPU) coldata(data uint8) {
 	}
 	if (data & 0x20) != 0 {
 		ppu.colorMath.red = intensity
+	}
+}
+
+func (ppu *PPU) applyColorMath(base []render.Pixel) {
+	for i := range base {
+		if ppu.colorMath.opSign == 1 {
+			base[i].Color.Color = base[i].Color.Color + ppu.subScreen[i].Color.Color
+		} else {
+			base[i].Color.Color = base[i].Color.Color + ppu.subScreen[i].Color.Color
+		}
+		if ppu.colorMath.div2 {
+			base[i].Color.Color /= 2
+		}
 	}
 }

--- a/core/ppu_colormath.go
+++ b/core/ppu_colormath.go
@@ -64,12 +64,12 @@ func (ppu *PPU) coldata(data uint8) {
 func (ppu *PPU) applyColorMath(base []render.Pixel) {
 	for i := range base {
 		if ppu.colorMath.opSign == 1 {
-			base[i].Color.Color = base[i].Color.Color + ppu.subScreen[i].Color.Color
+			base[i].Color = base[i].Color.Add(ppu.subScreen[i].Color)
 		} else {
-			base[i].Color.Color = base[i].Color.Color + ppu.subScreen[i].Color.Color
+			base[i].Color = base[i].Color.Sub(ppu.subScreen[i].Color)
 		}
 		if ppu.colorMath.div2 {
-			base[i].Color.Color /= 2
+			base[i].Color = base[i].Color.Halve()
 		}
 	}
 }

--- a/core/ppu_display.go
+++ b/core/ppu_display.go
@@ -38,7 +38,7 @@ func (ppu *PPU) tm(data uint8) {
 	for i := uint8(0); i < 4; i++ {
 		ppu.backgroundData.bg[i].mainScreen = data&(1<<i) != 0
 	}
-	ppu.oam.mainScreen = data&0x01 != 0
+	ppu.oam.mainScreen = data&0x10 != 0
 }
 
 // 212Dh - TS - Sub Screen Designation (W)
@@ -47,7 +47,7 @@ func (ppu *PPU) ts(data uint8) {
 		ppu.backgroundData.bg[i].subScreen = data&(1<<i) != 0
 		data = data >> 1
 	}
-	ppu.oam.subScreen = data&0x01 != 0
+	ppu.oam.subScreen = data&0x10 != 0
 }
 
 // 2133h - SETINI - Display Control 2 (W)

--- a/core/ppu_display.go
+++ b/core/ppu_display.go
@@ -45,7 +45,6 @@ func (ppu *PPU) tm(data uint8) {
 func (ppu *PPU) ts(data uint8) {
 	for i := uint8(0); i < 4; i++ {
 		ppu.backgroundData.bg[i].subScreen = data&(1<<i) != 0
-		data = data >> 1
 	}
 	ppu.oam.subScreen = data&0x10 != 0
 }

--- a/core/ppu_oam.go
+++ b/core/ppu_oam.go
@@ -116,10 +116,10 @@ func (o *oam) allSprites() []sprite {
 func (o *oam) intersectingSprites(vCounter uint16) []sprite {
 	sprites := make([]sprite, 0, 128)
 
-	for i := 0; i < 128; i++ {
-		s := o.sprite(uint16(i))
+	for i := uint16(0); i < 128; i++ {
+		s := o.sprite(i)
 		if s.IntersectsLine(vCounter) {
-			sprites = append(sprites, o.sprite(uint16(i)))
+			sprites = append(sprites, o.sprite(i))
 		}
 	}
 

--- a/core/ppu_render.go
+++ b/core/ppu_render.go
@@ -243,7 +243,11 @@ func (ppu *PPU) spritesToPixelLine(sprites []sprite) []render.Pixel {
 	// Initialize pixel line
 	pixels := make([]render.Pixel, WIDTH)
 
-	for _, sprite := range sprites {
+	if ppu.oam.priorityBit {
+		log.Error("sprite priority rotation not implemented")
+	}
+	for i := len(sprites) - 1; i >= 0; i-- {
+		sprite := sprites[i]
 		// Y coordinate of the tile containing the line
 		yTile := (ppu.vCounter - sprite.y) / TILE_SIZE
 		if sprite.vFlip {

--- a/core/ppu_render.go
+++ b/core/ppu_render.go
@@ -302,7 +302,7 @@ func (ppu *PPU) backgroundToPixelLine(bgIndex uint8) []render.Pixel {
 	yBaseTile := (ppu.vCounter + bg.verticalScroll - yBgTile*vTileSize) / TILE_SIZE
 
 	//Y coordinate of the line inside the base tile
-	yBase := (ppu.vCounter + bg.verticalScroll - yBgTile*vTileSize - yBaseTile*TILE_SIZE)
+	yBase := (ppu.vCounter + bg.verticalScroll - yBgTile*vTileSize) % TILE_SIZE
 
 	//go through the background tiles
 	hStart := bg.horizontalScroll
@@ -314,7 +314,7 @@ func (ppu *PPU) backgroundToPixelLine(bgIndex uint8) []render.Pixel {
 		yTile := yBaseTile
 		y := yBase
 		if bgTile.vFlip {
-			yTile = vTileSize - yTile - 1
+			yTile = vTileSize/TILE_SIZE - yTile - 1
 			y = TILE_SIZE - y - 1
 		}
 

--- a/core/ppu_vram.go
+++ b/core/ppu_vram.go
@@ -99,7 +99,7 @@ func (ppu *PPU) rdvramh() uint8 {
 
 func (vr *vram) prefetchWord() {
 	newAddr := vr.getAddr()
-	vr.prefetch = bit.JoinUint16(vr.bytes[2*newAddr+1], vr.bytes[2*newAddr])
+	vr.prefetch = bit.JoinUint16(vr.bytes[2*newAddr], vr.bytes[2*newAddr+1])
 }
 
 func (vr *vram) prefetchAndIncrAddr() {

--- a/render/pixel.go
+++ b/render/pixel.go
@@ -76,3 +76,50 @@ func bgr555ModelFunc(c color.Color) color.Color {
 		Transparent: false,
 	}
 }
+
+//Add 2 colors, channel by channel without wrapping
+func (c1 BGR555) Add(c2 BGR555) BGR555 {
+	r := (c1.Color&0x1F + c2.Color&0x1F)
+	g := (c1.Color>>5)&0x1F + (c2.Color>>5)&0x1F
+	b := (c1.Color>>10)&0x1F + (c2.Color>>10)&0x1F
+	if r > 0x1F {
+		r = 0x1F
+	}
+	if g > 0x1F {
+		g = 0x1F
+	}
+	if b > 0x1F {
+		b = 0x1F
+	}
+
+	return BGR555{
+		Color: r | g<<5 | b<<10,
+	}
+
+}
+
+//Substract 2 colors, channel by channel without wrapping
+func (c1 BGR555) Sub(c2 BGR555) BGR555 {
+	r := (c1.Color&0x1F - c2.Color&0x1F)
+	g := (c1.Color>>5)&0x1F - (c2.Color>>5)&0x1F
+	b := (c1.Color>>10)&0x1F - (c2.Color>>10)&0x1F
+	if r > 0x1F {
+		r = 0
+	}
+	if g > 0x1F {
+		g = 0
+	}
+	if b > 0x1F {
+		b = 0
+	}
+
+	return BGR555{
+		Color: r | g<<5 | b<<10,
+	}
+}
+
+func (c BGR555) Halve() BGR555 {
+	return BGR555{
+		Color: c.Color >> 1,
+	}
+}

--- a/render/screen.go
+++ b/render/screen.go
@@ -22,11 +22,11 @@ func NewScreen(width, height uint16) *Screen {
 	}
 }
 
-func (s *Screen) SetPixelLine(line uint16, priority uint8, pixels []Pixel) {
+func (s *Screen) SetPixelLine(line uint16, pixels []Pixel) {
 	if line < s.Height {
 		start := int(line * s.Width)
 		for i, pix := range pixels[:s.Width] {
-			if pix.Visible && pix.Priority == priority {
+			if pix.Visible {
 				s.Pixels[start+i] = pix
 			}
 		}


### PR DESCRIPTION
- each background layer and the sprite layer can be painted on the main and or the sub screen. Then if color math is enable for a layer, the layer on the main screen is combined with the whole sub screen before being composited on the main screen: https://wiki.superfamicom.org/transparency


- fix stz instruction, dependent on the m flag