### PR TITLE
render: add a command to render the screen as an image to use test roms more easily

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,12 +6,16 @@ var (
 	debugServer bool
 	debugLogs   bool
 	debugPort   int
+	nCycles     int
+	imgPath     string
 )
 
 func init() {
 	flag.BoolVar(&debugServer, "debug-server", false, "enable the debug server")
 	flag.BoolVar(&debugLogs, "debug-logs", false, "enable debug logs")
 	flag.IntVar(&debugPort, "debug-port", 6060, "port the debugger listens to")
+	flag.IntVar(&nCycles, "n-cycles", 10_000_000, "number of CPU cycles to execute before exiting (only used in 'save screen as image mode')")
+	flag.StringVar(&imgPath, "image-path", "", "where to store the screen as an image (the emulator will exit after ${n-cycles} CPU cycles)")
 }
 
 // Inits the config
@@ -32,4 +36,14 @@ func DebugServer() bool {
 // DebugPort is the port the debugger listens to
 func DebugPort() int {
 	return debugPort
+}
+
+// ImagePath is the path to the file we should use to store the screen as an image (it can be empty -> non set)
+func ImagePath() string {
+	return imgPath
+}
+
+// NCycles is the number of CPU cycles we should execute before storing the screen as an image (only used when ImagePath is not empty)
+func NCycles() int {
+	return nCycles
 }

--- a/main.go
+++ b/main.go
@@ -31,32 +31,42 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: fix dimension
-	renderer, err := render.NewRenderer(int(core.WIDTH), int(core.HEIGHT))
-	if err != nil {
-		log.Fatal("failed to init renderer", zap.Error(err))
-	}
-	emu := core.New(renderer, config.DebugServer())
-	emu.ReadROM(flag.Arg(0))
-
-	if config.DebugServer() {
-		log.Info("starting the debugger")
-		db := debugger.New(emu, fmt.Sprintf("localhost:%d", config.DebugPort()))
-		db.Start()
-	}
-
-	emu.Start()
-
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		<-sigs
+	if config.ImagePath() != "" {
+		renderer := render.NewImageRenderer(core.WIDTH, core.HEIGHT, config.ImagePath())
+		emu := core.New(renderer, true)
+		emu.ReadROM(flag.Arg(0))
+		emu.Start()
+		emu.StepAndWait(config.NCycles())
 		emu.Stop()
-		log.Info("emulation stopped")
-		os.Exit(0)
-	}()
+		renderer.Stop() // TODO: move into emu.Stop()
+	} else {
+		renderer, err := render.NewRenderer(int(core.WIDTH), int(core.HEIGHT))
+		if err != nil {
+			log.Fatal("failed to init renderer", zap.Error(err))
+		}
 
-	//should be run on the main thread
-	renderer.Run()
+		emu := core.New(renderer, config.DebugServer())
+		emu.ReadROM(flag.Arg(0))
+
+		if config.DebugServer() {
+			log.Info("starting the debugger")
+			db := debugger.New(emu, fmt.Sprintf("localhost:%d", config.DebugPort()))
+			db.Start()
+		}
+
+		emu.Start()
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+		go func() {
+			<-sigs
+			emu.Stop()
+			log.Info("emulation stopped")
+			os.Exit(0)
+		}()
+
+		//should be run on the main thread
+		renderer.Run()
+	}
 }

--- a/render/image_renderer.go
+++ b/render/image_renderer.go
@@ -1,0 +1,65 @@
+package render
+
+import (
+	"fmt"
+	"image"
+	"image/png"
+	"os"
+
+	"github.com/snes-emu/gose/log"
+	"go.uber.org/zap"
+)
+
+var _ Renderer = &ImageRenderer{}
+
+type ImageRenderer struct {
+	width  int
+	height int
+	path   string
+	Image  *image.RGBA
+}
+
+func NewImageRenderer(width, height int, path string) *ImageRenderer {
+	var image = image.NewRGBA(image.Rectangle{Min: image.Point{0, 0}, Max: image.Point{X: width, Y: height}})
+	return &ImageRenderer{Image: image, width: width, height: height, path: path}
+}
+
+func (i *ImageRenderer) Render(screen *Screen) {
+	for x := 0; x < i.width; x++ {
+		for y := 0; y < i.height; y++ {
+			i.Image.Set(x, y, screen.At(x, y))
+		}
+	}
+}
+
+func (i *ImageRenderer) saveToFile() error {
+	file, err := os.Create(i.path)
+	if err != nil {
+		return fmt.Errorf("failed to create file at: %s: %w", i.path, err)
+	}
+
+	err = png.Encode(file, i.Image)
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("failed to encode screen as png: %w", err)
+	}
+
+	return file.Close()
+}
+
+func (i ImageRenderer) Stop() {
+	err := i.saveToFile()
+	if err != nil {
+		log.Error("Failed to save image file", zap.Error(err))
+	} else {
+		log.Info("Saved screen at path", zap.String("path", i.path))
+	}
+}
+
+func (i ImageRenderer) SetRomTitle(string) {
+	// no-op
+}
+
+func (i ImageRenderer) Run() {
+	// no-op
+}


### PR DESCRIPTION
Example of usage:

```
>>>  ./gose -image-path /tmp/test.png ~/Downloads/CPUJMP.sfc
2021-05-10T19:55:08.139+0200    INFO    gose/main.go:27 starting gose   {"version": "sami/run-until-and-save-img:492d1a9b4e9547ffc72883b4228e035788bbbeba"}
2021-05-10T19:55:08.150+0200    INFO    core/core.go:122        success parsing rom     {"name": "65816 CPU TEST JMP   "}
2021-05-10T19:55:10.557+0200    INFO    render/image_renderer.go:55     Saved screen at path    {"path": "/tmp/test.png"}
```

outputs:

![test](https://user-images.githubusercontent.com/24794538/117703148-b2b9dc80-b1c9-11eb-8fda-00e64fe9ea1c.png)
